### PR TITLE
Chown directories to parent

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -538,9 +538,9 @@ issue() {
       mkdir -p "$wellknown_path"
       echo -n "$keyauthorization" > "$wellknown_path/$token"
 
-      webroot_owner=$(stat -c '%U' $Le_Webroot)
-      _debug "Changing owner of .well-known to $webroot_owner"
-      chown -R $webroot_owner. "$Le_Webroot/.well-known"
+      webroot_owner=$(stat -c '%U:%G' $Le_Webroot)
+      _debug "Changing owner/group of .well-known to $webroot_owner"
+      chown -R $webroot_owner "$Le_Webroot/.well-known"
 
     fi
     wellknown_url="http://$d/.well-known/acme-challenge/$token"

--- a/le.sh
+++ b/le.sh
@@ -537,6 +537,11 @@ issue() {
       
       mkdir -p "$wellknown_path"
       echo -n "$keyauthorization" > "$wellknown_path/$token"
+
+      webroot_owner=$(stat -c '%U' $Le_Webroot)
+      _debug "Changing owner of .well-known to $webroot_owner"
+      chown -R $webroot_owner. "$Le_Webroot/.well-known"
+
     fi
     wellknown_url="http://$d/.well-known/acme-challenge/$token"
     _debug wellknown_url "$wellknown_url"


### PR DESCRIPTION
- You might configure web-servers to not allow reading files owned by root (or user you execute as), modified script to try chowning the .well-known recursively
- If you do not have chown rights it will work anyway