### PR TITLE
renew() should return the function result code of issue()

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -892,7 +892,10 @@ renew() {
   
   IS_RENEW="1"
   issue "$Le_Webroot" "$Le_Domain" "$Le_Alt" "$Le_Keylength" "$Le_RealCertPath" "$Le_RealKeyPath" "$Le_RealCACertPath" "$Le_ReloadCmd"
+  local res=$?
   IS_RENEW=""
+
+  return $res
 }
 
 renewAll() {


### PR DESCRIPTION
previously the `renew` function always returned `0` even when the certificate issuing failed. for now return the function return code of `issue()` which will be `0` if the cert was issued, `1` if there was an error or `2` if there was no need for reissuing (renewal time not reached)

fixes #68 and as such enables custom scripting: in our environment, additional extra steps after a *successful* renewal have to be taken.