### PR TITLE
Add post-renew hook

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -412,9 +412,6 @@ _initpath() {
   if [ -z "$CA_CERT_PATH" ] ; then
     CA_CERT_PATH="$domainhome/ca.cer"
   fi
-  if [ -z "$POST_RENEW_PATH" ] ; then
-    POST_RENEW_PATH="$domainhome/post-renew.sh"
-  fi
 
 }
 
@@ -962,9 +959,6 @@ renew() {
   local res=$?
   IS_RENEW=""
 
-  if [ -x "$POST_RENEW_PATH" -a "$res" -eq "0" ] ; then
-    (cd $DOMAIN_PATH && exec $POST_RENEW_PATH)
-  fi
   return $res
 }
 
@@ -996,15 +990,14 @@ renewAll() {
 
     Le_ReloadCmd=""
     
-    DOMAIN_CONF=""
     DOMAIN_PATH=""
+    DOMAIN_CONF=""
     DOMAIN_SSL_CONF=""
     CSR_PATH=""
     CERT_KEY_PATH=""
     CERT_PATH=""
     CA_CERT_PATH=""
     ACCOUNT_KEY_PATH=""
-    POST_RENEW_PATH=""
     
     wellknown_path=""
     
@@ -1061,7 +1054,7 @@ installcert() {
 
   if [ "$Le_ReloadCmd" ] ; then
     _info "Run Le_ReloadCmd: $Le_ReloadCmd"
-    eval $Le_ReloadCmd
+    (cd $DOMAIN_PATH && eval $Le_ReloadCmd)
   fi
 
 }

--- a/le.sh
+++ b/le.sh
@@ -389,6 +389,9 @@ _initpath() {
   domainhome="$LE_WORKING_DIR/$domain"
   mkdir -p "$domainhome"
 
+  if [ -z "$DOMAIN_PATH" ] ; then
+    DOMAIN_PATH="$domainhome"
+  fi
   if [ -z "$DOMAIN_CONF" ] ; then
     DOMAIN_CONF="$domainhome/$Le_Domain.conf"
   fi
@@ -408,6 +411,9 @@ _initpath() {
   fi
   if [ -z "$CA_CERT_PATH" ] ; then
     CA_CERT_PATH="$domainhome/ca.cer"
+  fi
+  if [ -z "$POST_RENEW_PATH" ] ; then
+    POST_RENEW_PATH="$domainhome/post-renew.sh"
   fi
 
 }
@@ -956,6 +962,9 @@ renew() {
   local res=$?
   IS_RENEW=""
 
+  if [ -x "$POST_RENEW_PATH" -a "$res" -eq "0" ] ; then
+    (cd $DOMAIN_PATH && exec $POST_RENEW_PATH)
+  fi
   return $res
 }
 
@@ -988,12 +997,14 @@ renewAll() {
     Le_ReloadCmd=""
     
     DOMAIN_CONF=""
+    DOMAIN_PATH=""
     DOMAIN_SSL_CONF=""
     CSR_PATH=""
     CERT_KEY_PATH=""
     CERT_PATH=""
     CA_CERT_PATH=""
     ACCOUNT_KEY_PATH=""
+    POST_RENEW_PATH=""
     
     wellknown_path=""
     


### PR DESCRIPTION
Allows for running commands when the certificate is renewed. The command is only run if a) the file exists and is executable by the current user and b) the certificate renewal was a success.

I needed a way to send the key to ESXi when the cert was renewed. The following is an example of a post-renew.sh file:

    #!/bin/bash

    scp esx.example.com.cer root@esx:/etc/vmware/ssl/rui.crt
    scp esx.example.com.key root@esx:/etc/vmware/ssl/rui.key
    ssh root@esx 'services.sh restart' > restart.log