### PR TITLE
Update initconf

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1150,22 +1150,22 @@ _initconf() {
 #######################
 #Cloudflare:
 #api key
-#CF_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
+#CF_Key=\"sdfsdfsdfljlbjkljlkjsdfoiwje\"
 #account email
-#CF_Email="xxxx@sss.com"
+#CF_Email=\"xxxx@sss.com\"
 
 #######################
 #Dnspod.cn:
 #api key id
-#DP_Id="1234"
+#DP_Id=\"1234\"
 #api key
-#DP_Key="sADDsdasdgdsf"
+#DP_Key=\"sADDsdasdgdsf\"
 
 #######################
 #Cloudxns.com:
-#CX_Key="1234"
+#CX_Key=\"1234\"
 #
-#CX_Secret="sADDsdasdgdsf"
+#CX_Secret=\"sADDsdasdgdsf\"
 
     " > $ACCOUNT_CONF_PATH
   fi

--- a/le.sh
+++ b/le.sh
@@ -1140,6 +1140,7 @@ _initconf() {
     echo "#Account configurations:
 #Here are the supported macros, uncomment them to make them take effect.
 #ACCOUNT_EMAIL=aaa@aaa.com  # the account email used to register account.
+#ACCOUNT_KEY_PATH=\"/path/to/account.key\"
 
 #STAGE=1 # Use the staging api
 #FORCE=1 # Force to issue cert


### PR DESCRIPTION
Making it obvious that ACCOUNT_KEY_PATH can be set in the account config file seems like a good idea to me - the cron/renewAll function resets the ACCOUNT_KEY_PATH set via the environment, so the config file is the only way to set this for cron/renewAll.

This behaviour is needed for setups where the account config and key files are shared between hosts, but the LE_WORKING_DIR is not.

The second commit just fixes non escaped quotes in an echo statement.