### PR TITLE
Fix dns error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,19 @@ In all the cases, the issued cert will be placed in "~/.le/domain.com/"
 
  
 # Just issue a cert:
+Example 1:
+Only one domain:
+```
+le issue   /home/wwwroot/aa.com    aa.com 
+```
+
+Example 2:
+Multiple domains in the same cert:
+
 ```
 le issue   /home/wwwroot/aa.com    aa.com    www.aa.com,cp.aa.com
 ```
+
 First argument `/home/wwwroot/aa.com` is the web root folder, You must have `write` access to this folder.
 
 Second argument "aa.com" is the main domain you want to issue cert for.

--- a/le.sh
+++ b/le.sh
@@ -765,7 +765,7 @@ issue() {
         
         addcommand="$Le_Webroot-add"
         if ! command -v $addcommand ; then 
-          _err "It seems that your api file is not correct, it must have a function named: $Le_Webroot"
+          _err "It seems that your api file is not correct, it must have a function named: $Le_Webroot-add"
           return 1
         fi
         


### PR DESCRIPTION
Fixed error message when dns api function is not found in dos api file.