### PR TITLE
In case /home/ivan/.le points to a symlink, it does not displays the …

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1097,7 +1097,7 @@ renewAll() {
   _initpath
   _info "renewAll"
   
-  for d in $(ls -F $LE_WORKING_DIR | grep [^.].*[.].*/$ ) ; do
+  for d in $(ls -F ${LE_WORKING_DIR}/ | grep [^.].*[.].*/$ ) ; do
     d=$(echo $d | cut -d '/' -f 1)
     _info "renew $d"
     


### PR DESCRIPTION
…contents with a simple 'ls'. Added a slash to force list the folder content.

I use repositories for almost everything, and .le folder (with the certicates, configuration, etc) is not an exception.
When trying to test the renew (using stagging) I figured out it does not works because it is a symlink. Simply adding a trailing / is enough to make it work.