### PR TITLE
Fix for parsing status in response

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1142,7 +1142,7 @@ issue() {
         return 1
       fi
       
-      status=$(echo $response | egrep -o  '"status":"[^"]+"' | cut -d : -f 2 | tr -d '"')
+      status=$(echo $response | egrep -o  '"status":"[^"]*' | cut -d : -f 2 | tr -d '"')
       if [ "$status" == "valid" ] ; then
         _info "Success"
         _stopserver $serverproc


### PR DESCRIPTION
The JSON `status` attribute wasn't being parsed and that caused the rest of the process to fail because the `status` variable was blank.  I changed it to be like the other JSON parsing (i.e. `entry` and `token`) and it now works.