### PR TITLE
Fix broken certificate backup in installcert when RealCACertPath == RealCertPath

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1349,13 +1349,13 @@ installcert() {
   fi
   
   if [ "$Le_RealCACertPath" ] ; then
-    if [ -f "$Le_RealCACertPath" ] ; then
-      cp -p "$Le_RealCACertPath" "$Le_RealCACertPath".bak
-    fi
     if [ "$Le_RealCACertPath" == "$Le_RealCertPath" ] ; then
       echo "" >> "$Le_RealCACertPath"
       cat "$CA_CERT_PATH" >> "$Le_RealCACertPath"
     else
+      if [ -f "$Le_RealCACertPath" ] ; then
+        cp -p "$Le_RealCACertPath" "$Le_RealCACertPath".bak
+      fi
       cat "$CA_CERT_PATH" > "$Le_RealCACertPath"
     fi
   fi


### PR DESCRIPTION
On installcert both cert and cacert are saved in .bak files.    
When RealCACertPath == RealCertPath, eg. the certs are concatenated, there is only one cert file. However, in installcert this single file is moved **twice** to .bak:   
* once **before** coping the cert    
* and then **again, after** the new cert has been copied into it.    

After this, the original chained cert is lost and can't be restored from the .bak file.

This PR moves the copy of the cacert to .bak file into the right conditional block so the backup works in all conditions.