### PR TITLE
Set ACCOUNT_KEY_PATH and ACCOUNT_EMAIL in _initconf()

### DIFF
--- a/le.sh
+++ b/le.sh
@@ -1609,6 +1609,13 @@ USER_AGENT=\"le.sh client: $PROJECT\"
 
     " > $ACCOUNT_CONF_PATH
   fi
+  if [ -n "$ACCOUNT_KEY_PATH" ]; then
+    _sed_i "s/^#ACCOUNT_KEY_PATH=.*$/ACCOUNT_KEY_PATH=\"${ACCOUNT_KEY_PATH//\//\\\/}\"/g" "$ACCOUNT_CONF_PATH"
+  fi
+
+  if [ -n "$ACCOUNT_EMAIL" ]; then
+    _sed_i "s/^#ACCOUNT_EMAIL=.*$/ACCOUNT_EMAIL=\"${ACCOUNT_EMAIL//\//\\\/}\"/g" "$ACCOUNT_CONF_PATH"
+  fi
 }
 
 _precheck() {


### PR DESCRIPTION
this enables the following one liner for initial configuration at install time, which would mean that most users would never need to touch their account.conf manually:

    ACCOUNT_CONF_PATH=/path/to/account.conf ACCOUNT_KEY_PATH=/path/to/account.key ACCOUNT_EMAIL=some@valid.email ./le.sh install